### PR TITLE
Change root directory for vite

### DIFF
--- a/portman_ui/index.html
+++ b/portman_ui/index.html
@@ -15,6 +15,6 @@
 </head>
 <body>
 <div id="root"></div>
-<script type="module" src="main.tsx"></script>
+<script type="module" src="src/main.tsx"></script>
 </body>
 </html>

--- a/portman_ui/vite.config.ts
+++ b/portman_ui/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '')
 
     return {
-        root: 'src',
         plugins: [react()],
         resolve: {
             alias: {
@@ -19,7 +18,7 @@ export default defineConfig(({ mode }) => {
             __API_BASE_URL__: JSON.stringify(env.VITE_API_BASE_URL), // Usage: __API_BASE_URL__
         },
         build: {
-            outDir: '../dist',
+            outDir: 'dist',
             emptyOutDir: true,
         },
         server: {


### PR DESCRIPTION
Change VITE configurations so that `/portman_ui/` directory is used as the UI root directory instead of `/portman_ui/src/` directory